### PR TITLE
[tools] bump formData to 0.0.2 and use short syntax for non-file post params

### DIFF
--- a/src/render/imports.js
+++ b/src/render/imports.js
@@ -46,7 +46,7 @@ const K6_JS_LIBS = (() => {
   return {
     jsonpath: `${BASE_URL}/jsonpath/1.0.2/index.js`,
     url: `${BASE_URL}/url/1.0.0/index.js`,
-    formData: `${BASE_URL}/formdata/0.0.1/index.js`,
+    formData: `${BASE_URL}/formdata/0.0.2/index.js`,
   }
 })()
 

--- a/src/render/post/multipart/fixed/pre.js
+++ b/src/render/post/multipart/fixed/pre.js
@@ -15,6 +15,10 @@ function generateAppendData(params) {
     (acc, [name, valueSet]) => [
       ...acc,
       ...Array.from(valueSet).map((value) => {
+        if (!value.type) {
+          return `formData.append(${text(name)}, ${text(value.value)})`
+        }
+
         const data = `data: ${text(value.value)}`
 
         let fileName = ''

--- a/test/e2e/pass/multipart-formdata.js
+++ b/test/e2e/pass/multipart-formdata.js
@@ -1,7 +1,7 @@
 import { sleep } from "k6";
 import http from "k6/http";
 
-import { FormData } from "https://jslib.k6.io/formdata/0.0.1/index.js";
+import { FormData } from "https://jslib.k6.io/formdata/0.0.2/index.js";
 
 export const options = {};
 
@@ -11,7 +11,7 @@ export default function main() {
   // Request 1
   formData = new FormData();
   formData.boundary = "---boundary";
-  formData.append("hello", { data: "world", content_type: "text/plain" });
+  formData.append("hello", "world");
 
   response = http.post("http://test.k6.io/value-pairs", formData.body(), {
     headers: {
@@ -38,10 +38,7 @@ export default function main() {
   // Request 3
   formData = new FormData();
   formData.boundary = "---boundary";
-  formData.append("hello", {
-    data: "`'\"world\"'`*!",
-    content_type: "text/plain",
-  });
+  formData.append("hello", "`'\"world\"'`*!");
 
   response = http.post("http://test.k6.io/value-pairs-chars", formData.body(), {
     headers: {
@@ -68,9 +65,9 @@ export default function main() {
   // Request 5
   formData = new FormData();
   formData.boundary = "---boundary";
-  formData.append("hello", { data: "world", content_type: "text/plain" });
-  formData.append("hola", { data: "amigo", content_type: "text/plain" });
-  formData.append("labas", { data: "pasauli", content_type: "text/plain" });
+  formData.append("hello", "world");
+  formData.append("hola", "amigo");
+  formData.append("labas", "pasauli");
 
   response = http.post(
     "http://test.k6.io/multiple-value-pairs",


### PR DESCRIPTION
Bump formData to 0.0.2 and use simplified short syntax for text fields:

Before:
```js
formData.append("hello", { data: "world", content_type: "text/plain" });
```

After:
```js
formData.append("hello", "world");
```