### PR TITLE
Run bundle on prepack hook rather than prepare.

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
         "test:watch": "cross-env NODE_PATH=src:test ava --watch test/unit",
         "test-hoc": "cross-env NODE_PATH=src:test ava",
         "test-only": "cross-env NODE_PATH=src:test ava",
-        "prepare": "npm-run-all bundle"
+        "prepack": "npm-run-all bundle"
     },
     "eslintConfig": {
         "env": {


### PR DESCRIPTION
Change to generate standalone.js bundle on prepack hook rather than prepare hook to support both yarn and npm.