### PR TITLE
[fix] various fixes related to weird input data

### DIFF
--- a/src/parse/postData.js
+++ b/src/parse/postData.js
@@ -3,6 +3,10 @@ const params = require('./params')
 function postData(node, spec) {
   spec.type = node.mimeType
 
+  if (spec.type === '') {
+    spec.type = 'text/plain'
+  }
+
   if (node.params && node.params.length) {
     spec.params = new Map()
     params(node.params, spec.params)

--- a/src/parse/postData.js
+++ b/src/parse/postData.js
@@ -1,11 +1,32 @@
+const { empty } = require('../aid')
 const params = require('./params')
 
-function postData(node, spec) {
-  spec.type = node.mimeType
-
-  if (spec.type === '') {
-    spec.type = 'text/plain'
+function inferMimeType(node) {
+  if (!empty(node.mimeType)) {
+    return node.mimeType
   }
+
+  if (Array.isArray(node.params) && node.params.length > 0) {
+    return 'application/x-www-form-urlencoded'
+  }
+
+  try {
+    const body = JSON.parse(node.text)
+
+    // We only assume it to be JSON if it's an object or array, because
+    // any other value might just as well be arbitrary text.
+    if (typeof body === 'object' && body !== null) {
+      return 'application/json'
+    }
+  } catch {
+    // Must not be JSON then.
+  }
+
+  return 'text/plain'
+}
+
+function postData(node, spec) {
+  spec.type = inferMimeType(node)
 
   if (node.params && node.params.length) {
     spec.params = new Map()

--- a/src/parse/queryItem.js
+++ b/src/parse/queryItem.js
@@ -1,11 +1,14 @@
 function queryItem(node, spec) {
   const item = {}
+
   if (node.value) {
     item.value = node.value
   }
+
   if (node.comment) {
     item.comment = node.comment
   }
+
   if (node.name) {
     if (!spec.has(node.name)) {
       spec.set(node.name, new Set())

--- a/src/parse/request.js
+++ b/src/parse/request.js
@@ -4,6 +4,8 @@ const queryString = require('./queryString')
 const state = require('./state/request')
 const { emptyObject, getContentTypeValue } = require('../aid')
 
+const EMPTY_BODY_METHODS = ['HEAD', 'GET', 'OPTIONS']
+
 function request(node, spec) {
   spec.method = node.method.toUpperCase()
   spec.address = node.url
@@ -20,7 +22,11 @@ function request(node, spec) {
     headers(node.headers, spec.headers)
   }
 
-  if (node.postData && !emptyObject(node.postData)) {
+  if (
+    !EMPTY_BODY_METHODS.includes(node.method) &&
+    node.postData &&
+    !emptyObject(node.postData)
+  ) {
     postData(node.postData, spec.post)
     contentType(node.postData.mimeType, spec.headers)
   }
@@ -47,7 +53,7 @@ function addBoundary(boundary, headers) {
 
   if (contentType) {
     const items = [...contentType.values()]
-    const newItems = items.map((item) => {
+    const newItems = items.map(item => {
       const value = getContentTypeValue(item.value)
       if (value === 'multipart/form-data') {
         return { value: `${value}; boundary=${boundary}` }

--- a/src/validate/param.js
+++ b/src/validate/param.js
@@ -17,7 +17,10 @@ function param(node, i, j) {
 function validate(node, i, j) {
   if (empty(node.name)) {
     console.warn(`[WARN] Discarding param with missing name (${i}:${j})`)
+
+    return
   }
+
   if (typeof node.name !== 'string') {
     throw new InvalidArchiveError(
       createErrorParams({
@@ -28,6 +31,7 @@ function validate(node, i, j) {
       `Param name must be a string`
     )
   }
+
   if (node.value && typeof node.value !== 'string') {
     throw new InvalidArchiveError(
       createErrorParams({
@@ -38,6 +42,7 @@ function validate(node, i, j) {
       `Param value must be a string`
     )
   }
+
   if (node.fileName && typeof node.fileName !== 'string') {
     throw new InvalidArchiveError(
       createErrorParams({
@@ -48,6 +53,7 @@ function validate(node, i, j) {
       `Param file name must be a string`
     )
   }
+
   if (node.contentType && typeof node.contentType !== 'string') {
     throw new InvalidArchiveError(
       createErrorParams({
@@ -58,6 +64,7 @@ function validate(node, i, j) {
       `Param content type must be a string`
     )
   }
+
   if (node.comment && typeof node.comment !== 'string') {
     throw new InvalidArchiveError(
       createErrorParams({

--- a/src/validate/postData.js
+++ b/src/validate/postData.js
@@ -32,7 +32,7 @@ function validate(node, i) {
 
   if (mimeType === '') {
     console.warn(
-      `[WARN] Post data mimeType is missing and will be assumed to be text/plain (${i})`
+      `[WARN] Post data MIME type is missing and will be inferred from the content (${i})`
     )
   }
 

--- a/src/validate/postData.js
+++ b/src/validate/postData.js
@@ -28,18 +28,15 @@ function postData(node, i, assay) {
 }
 
 function validate(node, i) {
-  if (empty(node.mimeType)) {
-    throw new InvalidArchiveError(
-      createErrorParams({
-        name: 'MissingPostDataType',
-        index: i,
-        path: 'mimeType',
-      }),
-      `Post data MIME type is required`
+  const mimeType = empty(node.mimeType) ? '' : node.mimeType
+
+  if (mimeType === '') {
+    console.warn(
+      `[WARN] Post data mimeType is missing and will be assumed to be text/plain (${i})`
     )
   }
 
-  if (typeof node.mimeType !== 'string') {
+  if (typeof mimeType !== 'string') {
     throw new InvalidArchiveError(
       createErrorParams({
         name: 'InvalidPostDataType',

--- a/src/validate/queryItem.js
+++ b/src/validate/queryItem.js
@@ -1,3 +1,4 @@
+const { empty } = require('../aid')
 const { InvalidArchiveError } = require('../error')
 const { createQueryStringPath } = require('./utils/path')
 const { createQueryStringIndexes } = require('./utils/indexes')
@@ -12,6 +13,12 @@ function queryItem(node, i, j) {
 }
 
 function validate(node, i, j) {
+  if (empty(node.name)) {
+    console.warn(`[WARN] Discarding query item with missing name (${i}:${j})`)
+
+    return
+  }
+
   if (typeof node.name !== 'string') {
     throw new InvalidArchiveError(
       createErrorParams({

--- a/src/validate/queryString.js
+++ b/src/validate/queryString.js
@@ -7,11 +7,11 @@ const { createQueryStringIndexes } = require('./utils/indexes')
 /*
  * [j]: object
  */
-function queryString(node, i, assay) {
+function queryString(node, i) {
   validate(node, i)
   for (let j = 0; j < node.length; j++) {
     const item = node[j]
-    queryItem(item, i, j, assay)
+    queryItem(item, i, j)
   }
 }
 

--- a/src/validate/request.js
+++ b/src/validate/request.js
@@ -49,6 +49,7 @@ function validate(node, i) {
       `Request method is required`
     )
   }
+
   if (typeof node.method !== 'string') {
     throw new InvalidArchiveError(
       createErrorParams({
@@ -59,24 +60,28 @@ function validate(node, i) {
       `Request method must be one of: 'GET', 'POST', 'PUT', 'PATCH', 'OPTIONS', 'DELETE', 'HEAD'`
     )
   }
+
   if (empty(node.url)) {
     throw new InvalidArchiveError(
       createErrorParams({ name: 'MissingRequestUrl', index: i, path: 'url' }),
       `Request URL is required`
     )
   }
+
   if (typeof node.url !== 'string') {
     throw new InvalidArchiveError(
       createErrorParams({ name: 'InvalidRequestUrl', index: i, path: 'url' }),
       `Request URL must be a string`
     )
   }
+
   if (!(absoluteUrl.test(node.url) || variableStart.test(node.url))) {
     throw new InvalidArchiveError(
       createErrorParams({ name: 'InvalidRequestUrl', index: i, path: 'url' }),
       `Request URL must be absolute or start with variable`
     )
   }
+
   if (node.queryString && !Array.isArray(node.queryString)) {
     throw new InvalidArchiveError(
       createErrorParams({
@@ -87,6 +92,7 @@ function validate(node, i) {
       `Request queryString must be an array`
     )
   }
+
   if (node.headers && !Array.isArray(node.headers)) {
     throw new InvalidArchiveError(
       createErrorParams({
@@ -97,6 +103,7 @@ function validate(node, i) {
       `Request headers are invalid, must be an array`
     )
   }
+
   if (node.cookies && !Array.isArray(node.cookies)) {
     throw new InvalidArchiveError(
       createErrorParams({
@@ -107,6 +114,7 @@ function validate(node, i) {
       `Request cookies are invalid, must be an array`
     )
   }
+
   if (node.postData && !isPlainObject(node.postData)) {
     throw new InvalidArchiveError(
       createErrorParams({
@@ -117,6 +125,7 @@ function validate(node, i) {
       `Request postData must be a plain object`
     )
   }
+
   if (node.comment && typeof node.comment !== 'string') {
     throw new InvalidArchiveError(
       createErrorParams({
@@ -135,14 +144,7 @@ function relation(node, i) {
     node.postData &&
     !emptyObject(node.postData)
   ) {
-    throw new InvalidArchiveError(
-      createErrorParams({
-        name: 'InvalidRequestData',
-        index: i,
-        path: 'postData',
-      }),
-      `Request postData usage with GET requests is prohibited`
-    )
+    console.warn(`[WARN] GET request has postData object (${i})`)
   }
   if (
     node.headers &&

--- a/test/unit/parse/param.test.js
+++ b/test/unit/parse/param.test.js
@@ -5,37 +5,43 @@ function makeSpec() {
   return new Map()
 }
 
-test('minimal', (t) => {
+test('it should ignore the param if the name is empty', t => {
+  const spec = makeSpec()
+  param({ name: null }, spec)
+  t.deepEqual(spec, new Map())
+})
+
+test('it should use an empty object when only the name is given', t => {
   const spec = makeSpec()
   param({ name: 'search' }, spec)
   t.deepEqual(spec, new Map().set('search', new Set([{}])))
 })
 
-test('value', (t) => {
+test('it should set the value of params when a value is given', t => {
   const spec = makeSpec()
   param({ name: 'search', value: 'kittens' }, spec)
   t.deepEqual(spec, new Map().set('search', new Set([{ value: 'kittens' }])))
 })
 
-test('empty value', (t) => {
+test('it should set the value of params when it is empty', t => {
   const spec = makeSpec()
   param({ name: 'search', value: '' }, spec)
   t.deepEqual(spec, new Map().set('search', new Set([{ value: '' }])))
 })
 
-test('fileName', (t) => {
+test('it should set the fileName of params when a fileName is given', t => {
   const spec = makeSpec()
   param({ name: 'data', fileName: 'data.csv' }, spec)
   t.deepEqual(spec, new Map().set('data', new Set([{ fileName: 'data.csv' }])))
 })
 
-test('contentType', (t) => {
+test('it should set the contentType of params when a contentType is given', t => {
   const spec = makeSpec()
   param({ name: 'data', contentType: 'text/csv' }, spec)
   t.deepEqual(spec, new Map().set('data', new Set([{ type: 'text/csv' }])))
 })
 
-test('comment', (t) => {
+test('it should set the comment of params when a comment is given', t => {
   const spec = makeSpec()
   param({ name: 'data', comment: 'Test importing data' }, spec)
   t.deepEqual(

--- a/test/unit/parse/postData.test.js
+++ b/test/unit/parse/postData.test.js
@@ -8,21 +8,21 @@ function makeSpec() {
   return {}
 }
 
-test.serial('basic', (t) => {
+test.serial('basic', t => {
   const spec = makeSpec()
   postData({ mimeType: 'text/plain' }, spec)
   t.deepEqual(spec, { type: 'text/plain' })
   t.true(params.notCalled)
 })
 
-test.serial('text', (t) => {
+test.serial('text', t => {
   const spec = makeSpec()
   postData({ mimeType: 'text/plain', text: 'Great post' }, spec)
   t.deepEqual(spec, { type: 'text/plain', value: 'Great post' })
   t.true(params.notCalled)
 })
 
-test.serial('params', (t) => {
+test.serial('params', t => {
   const spec = makeSpec()
   postData(
     {
@@ -38,14 +38,23 @@ test.serial('params', (t) => {
   t.true(params.calledOnce)
 })
 
-test.serial('allows chartset in mimeType', (t) => {
+test.serial('allows chartset in mimeType', t => {
   const spec = makeSpec()
   postData({ mimeType: 'text/plain;charset=UTF-8', text: 'Great post' }, spec)
   t.deepEqual(spec, { type: 'text/plain;charset=UTF-8', value: 'Great post' })
 })
 
-test.serial('comment', (t) => {
+test.serial('comment', t => {
   const spec = makeSpec()
   postData({ mimeType: 'text/plain', comment: 'Test post body' }, spec)
   t.deepEqual(spec, { type: 'text/plain', comment: 'Test post body' })
 })
+
+test.serial(
+  'it should assume mime-type is text/plain when mime-type is empty',
+  t => {
+    const spec = makeSpec()
+    postData({ mimeType: '', comment: 'Test post body' }, spec)
+    t.deepEqual(spec, { type: 'text/plain', comment: 'Test post body' })
+  }
+)

--- a/test/unit/parse/postData.test.js
+++ b/test/unit/parse/postData.test.js
@@ -38,7 +38,7 @@ test.serial('params', t => {
   t.true(params.calledOnce)
 })
 
-test.serial('allows chartset in mimeType', t => {
+test.serial('allows charset in mimeType', t => {
   const spec = makeSpec()
   postData({ mimeType: 'text/plain;charset=UTF-8', text: 'Great post' }, spec)
   t.deepEqual(spec, { type: 'text/plain;charset=UTF-8', value: 'Great post' })
@@ -56,5 +56,26 @@ test.serial(
     const spec = makeSpec()
     postData({ mimeType: '', comment: 'Test post body' }, spec)
     t.deepEqual(spec, { type: 'text/plain', comment: 'Test post body' })
+  }
+)
+
+test.serial(
+  'it should assume mime-type is application/x-www-form-urlencoded when mime-type is empty when a params array is present',
+  t => {
+    const spec = makeSpec()
+    postData({ mimeType: '', params: [{ name: 'param' }] }, spec)
+    t.deepEqual(spec, {
+      type: 'application/x-www-form-urlencoded',
+      params: new Map(),
+    })
+  }
+)
+
+test.serial(
+  'it should assume mime-type is application/json when text can be deserialized to a JSON-object',
+  t => {
+    const spec = makeSpec()
+    postData({ mimeType: '', text: '{ "prop": 1 }' }, spec)
+    t.deepEqual(spec, { type: 'application/json', value: '{ "prop": 1 }' })
   }
 )

--- a/test/unit/parse/queryItem.test.js
+++ b/test/unit/parse/queryItem.test.js
@@ -6,19 +6,25 @@ function makeSpec() {
   return new Map()
 }
 
-test('minimal', (t) => {
+test('it should ignore the query item when name is empty', t => {
+  const spec = makeSpec()
+  queryItem({ name: null }, spec, makeState())
+  t.deepEqual(spec, new Map())
+})
+
+test('it should use an empty set when only the name is given', t => {
   const spec = makeSpec()
   queryItem({ name: 'search' }, spec, makeState())
   t.deepEqual(spec, new Map().set('search', new Set([{}])))
 })
 
-test('value', (t) => {
+test('it should set the value of the query item when a value is given', t => {
   const spec = makeSpec()
   queryItem({ name: 'search', value: 'kittens' }, spec, makeState())
   t.deepEqual(spec, new Map().set('search', new Set([{ value: 'kittens' }])))
 })
 
-test('comment', (t) => {
+test('it should set the comment of the query item when a comment is given', t => {
   const spec = makeSpec()
   queryItem({ name: 'search', comment: 'Test a search' }, spec, makeState())
   t.deepEqual(

--- a/test/unit/parse/request.test.js
+++ b/test/unit/parse/request.test.js
@@ -13,7 +13,7 @@ const [request, { cookies, headers, postData, queryString, state }] = isolate(
   }
 )
 
-test.serial('basic', (t) => {
+test.serial('basic', t => {
   const spec = makeRequestSpec()
   request({ method: 'get', url: 'http://example.com' }, spec)
   t.is(spec.method, 'GET')
@@ -29,7 +29,7 @@ test.serial('basic', (t) => {
   t.true(state.calledOnce)
 })
 
-test.serial('comment', (t) => {
+test.serial('comment', t => {
   const spec = makeRequestSpec()
   request(
     {
@@ -42,7 +42,7 @@ test.serial('comment', (t) => {
   t.is(spec.comment, 'Load test home page')
 })
 
-test.serial('queryString', (t) => {
+test.serial('queryString', t => {
   request(
     {
       method: 'GET',
@@ -54,7 +54,7 @@ test.serial('queryString', (t) => {
   t.true(queryString.calledOnce)
 })
 
-test.serial('headers', (t) => {
+test.serial('headers', t => {
   request(
     {
       method: 'GET',
@@ -66,7 +66,7 @@ test.serial('headers', (t) => {
   t.true(headers.calledOnce)
 })
 
-test.serial('headers boundary', (t) => {
+test.serial('headers boundary', t => {
   const spec = makeRequestSpec()
   spec.state.post.boundary = 'foobar'
   spec.headers = new Map().set(
@@ -87,7 +87,7 @@ test.serial('headers boundary', (t) => {
   )
 })
 
-test.serial('postData', (t) => {
+test.serial('it should ignore postData when method is GET', t => {
   request(
     {
       method: 'GET',
@@ -96,10 +96,22 @@ test.serial('postData', (t) => {
     },
     makeRequestSpec()
   )
+  t.false(postData.calledOnce)
+})
+
+test.serial('it should add postData when method is POST', t => {
+  request(
+    {
+      method: 'POST',
+      url: 'http://example.com',
+      postData: { mimeType: 'text/plain' },
+    },
+    makeRequestSpec()
+  )
   t.true(postData.calledOnce)
 })
 
-test.serial('postData empty', (t) => {
+test.serial('postData empty', t => {
   request(
     {
       method: 'GET',

--- a/test/unit/validate/param.test.js
+++ b/test/unit/validate/param.test.js
@@ -2,7 +2,15 @@ import test from 'ava'
 import param from 'validate/param'
 import { assay as makeAssay } from 'make'
 
-test('invalid name', (t) => {
+test('should ignore errors when name is empty', t => {
+  t.notThrows(() => {
+    param({
+      name: null,
+    })
+  })
+})
+
+test('should throw when name is invalid', t => {
   t.throws(
     () => {
       param({ name: 5 }, 0, 0, makeAssay())
@@ -11,7 +19,7 @@ test('invalid name', (t) => {
   )
 })
 
-test('invalid value', (t) => {
+test('should throw when value is invalid', t => {
   t.throws(
     () => {
       param({ name: 'recordId', value: 5 }, 0, 0, makeAssay())
@@ -20,7 +28,7 @@ test('invalid value', (t) => {
   )
 })
 
-test('invalid file name', (t) => {
+test('should throw when file name is invalid', t => {
   t.throws(
     () => {
       param({ name: 'recordId', fileName: 5 }, 0, 0, makeAssay())
@@ -29,7 +37,7 @@ test('invalid file name', (t) => {
   )
 })
 
-test('invalid type', (t) => {
+test('should throw when type is invalid', t => {
   t.throws(
     () => {
       param({ name: 'recordId', contentType: 5 }, 0, 0, makeAssay())
@@ -38,7 +46,7 @@ test('invalid type', (t) => {
   )
 })
 
-test('invalid comment', (t) => {
+test('should throw when comment is invalid', t => {
   t.throws(
     () => {
       param({ name: 'recordId', comment: 5 }, 0, 0, makeAssay())
@@ -47,13 +55,13 @@ test('invalid comment', (t) => {
   )
 })
 
-test('valid minimal', (t) => {
+test('should not throw when minimal input is valid', t => {
   t.notThrows(() => {
     param({ name: 'recordId' }, 0, 0, makeAssay())
   })
 })
 
-test('valid full', (t) => {
+test('should not throw when full input is valid', t => {
   t.notThrows(() => {
     param(
       {

--- a/test/unit/validate/param.test.js
+++ b/test/unit/validate/param.test.js
@@ -55,13 +55,13 @@ test('should throw when comment is invalid', t => {
   )
 })
 
-test('should not throw when minimal input is valid', t => {
+test('should not throw when name is valid', t => {
   t.notThrows(() => {
     param({ name: 'recordId' }, 0, 0, makeAssay())
   })
 })
 
-test('should not throw when full input is valid', t => {
+test('should not throw when all values are valid', t => {
   t.notThrows(() => {
     param(
       {

--- a/test/unit/validate/postData.test.js
+++ b/test/unit/validate/postData.test.js
@@ -1,62 +1,58 @@
 import test from 'ava'
 import isolate from 'helper/isolate'
-import { assay as makeAssay } from 'make'
 const [postData, { params }] = isolate(test, 'validate/postData', {
   params: 'validate/params',
 })
 
-test.serial('empty', (t) => {
+test.serial('empty', t => {
   t.notThrows(() => {
-    postData({}, 0, makeAssay())
+    postData({}, 0)
   })
 })
 
-test.serial('missing type', (t) => {
-  t.throws(
-    () => {
-      postData({ text: 'Message in text' }, 0, makeAssay())
-    },
-    { name: 'MissingPostDataType' }
-  )
+test.serial('it should not throw when mimeType is missing', t => {
+  t.notThrows(() => {
+    postData({ text: 'Message in text' }, 0)
+  })
 })
 
-test.serial('invalid type', (t) => {
+test.serial('invalid type', t => {
   t.throws(
     () => {
-      postData({ mimeType: 5 }, 0, makeAssay())
+      postData({ mimeType: 5 }, 0)
     },
     { name: 'InvalidPostDataType' }
   )
 })
 
-test.serial('invalid params', (t) => {
+test.serial('invalid params', t => {
   t.throws(
     () => {
-      postData({ mimeType: 'text/plain', params: 5 }, 0, makeAssay())
+      postData({ mimeType: 'text/plain', params: 5 }, 0)
     },
     { name: 'InvalidPostDataParams' }
   )
 })
 
-test.serial('invalid text', (t) => {
+test.serial('invalid text', t => {
   t.throws(
     () => {
-      postData({ mimeType: 'text/plain', text: 5 }, 0, makeAssay())
+      postData({ mimeType: 'text/plain', text: 5 }, 0)
     },
     { name: 'InvalidPostDataText' }
   )
 })
 
-test.serial('invalid comment', (t) => {
+test.serial('invalid comment', t => {
   t.throws(
     () => {
-      postData({ mimeType: 'text/plain', comment: 5 }, 0, makeAssay())
+      postData({ mimeType: 'text/plain', comment: 5 }, 0)
     },
     { name: 'InvalidPostDataComment' }
   )
 })
 
-test.serial('invalid structured type', (t) => {
+test.serial('invalid structured type', t => {
   t.throws(
     () => {
       postData(
@@ -64,15 +60,14 @@ test.serial('invalid structured type', (t) => {
           mimeType: 'text/plain',
           params: [{}],
         },
-        0,
-        makeAssay()
+        0
       )
     },
     { name: 'InvalidPostDataType' }
   )
 })
 
-test.serial('valid postData combination', (t) => {
+test.serial('valid postData combination', t => {
   postData({
     mimeType: 'application/x-www-form-urlencoded',
     params: [
@@ -85,46 +80,43 @@ test.serial('valid postData combination', (t) => {
   t.true(params.calledOnce)
 })
 
-test.serial('valid minimal', (t) => {
+test.serial('valid minimal', t => {
   postData({ mimeType: 'text/plain' })
   t.true(params.notCalled)
 })
 
-test.serial('valid full params form-urlencoded', (t) => {
+test.serial('valid full params form-urlencoded', t => {
   postData(
     {
       mimeType: 'application/x-www-form-urlencoded',
       params: [{}],
       comment: 'Send URL encoded parameters',
     },
-    0,
-    makeAssay()
+    0
   )
   t.true(params.calledOnce)
 })
 
-test.serial('valid full params form-data', (t) => {
+test.serial('valid full params form-data', t => {
   postData(
     {
       mimeType: 'multipart/form-data',
       params: [{}],
       comment: 'Send multipart encoded parameters',
     },
-    0,
-    makeAssay()
+    0
   )
   t.true(params.calledOnce)
 })
 
-test.serial('valid full text', (t) => {
+test.serial('valid full text', t => {
   postData(
     {
       mimeType: 'text/plain',
       text: 'Message in text',
       comment: 'Send a text body',
     },
-    0,
-    makeAssay()
+    0
   )
   t.true(params.notCalled)
 })

--- a/test/unit/validate/queryItem.test.js
+++ b/test/unit/validate/queryItem.test.js
@@ -1,47 +1,52 @@
 import test from 'ava'
 import queryItem from 'validate/queryItem'
-import { assay as makeAssay } from 'make'
 
-test('invalid name', (t) => {
+test('should ignore errors when name is empty', t => {
+  t.notThrows(() => {
+    queryItem({ name: null, value: 123 }, 0, 0)
+  })
+})
+
+test('it should throw when name is invalid', t => {
   t.throws(
     () => {
-      queryItem({ name: 5 }, 0, 0, makeAssay())
+      queryItem({ name: 5 }, 0, 0)
     },
     { name: 'InvalidQueryItemName' }
   )
 })
 
-test('invalid value', (t) => {
+test('it should throw when value is invalid', t => {
   t.throws(
     () => {
-      queryItem({ name: 'search', value: 5 }, 0, 0, makeAssay())
+      queryItem({ name: 'search', value: 5 }, 0, 0)
     },
     { name: 'InvalidQueryItemValue' }
   )
 })
 
-test('invalid comment', (t) => {
+test('it should throw when comment is invalid', t => {
   t.throws(
     () => {
-      queryItem({ name: 'search', comment: 5 }, 0, 0, makeAssay())
+      queryItem({ name: 'search', comment: 5 }, 0, 0)
     },
     { name: 'InvalidQueryStringComment' }
   )
 })
 
-test('valid minimal', (t) => {
+test('it should not throw when given only a name', t => {
   t.notThrows(() => {
-    queryItem({ name: 'search' }, 0, 0, makeAssay())
+    queryItem({ name: 'search' }, 0, 0)
   })
 })
 
-test('valid empty value', (t) => {
+test('it should not throw when given an empty value', t => {
   t.notThrows(() => {
-    queryItem({ name: 'search', value: '' }, 0, 0, makeAssay())
+    queryItem({ name: 'search', value: '' }, 0, 0)
   })
 })
 
-test('valid full', (t) => {
+test('it should not throw when all values are valid', t => {
   t.notThrows(() => {
     queryItem(
       {
@@ -50,8 +55,7 @@ test('valid full', (t) => {
         comment: 'Typical search',
       },
       0,
-      0,
-      makeAssay()
+      0
     )
   })
 })

--- a/test/unit/validate/request.test.js
+++ b/test/unit/validate/request.test.js
@@ -2,7 +2,7 @@ import test from 'ava'
 import { assay as makeAssay } from 'make'
 import request from 'validate/request'
 
-const init = (requestBody) =>
+const init = requestBody =>
   Object.assign(
     {},
     {
@@ -17,32 +17,32 @@ const init = (requestBody) =>
     requestBody
   )
 
-test('missing method', (t) => {
+test('missing method', t => {
   t.throws(() => request(init({ method: null }), 0, makeAssay()), {
     name: 'MissingRequestMethod',
   })
 })
 
-test('invalid method', (t) => {
+test('invalid method', t => {
   t.throws(() => request(init({ method: 5 }), 0, makeAssay()), {
     name: 'InvalidRequestMethod',
   })
 })
 
-test('missing url', (t) => {
+test('missing url', t => {
   t.throws(() => request(init({ method: 'GET', url: null }), 0, makeAssay()), {
     name: 'MissingRequestUrl',
   })
 })
 
-test('invalid url type', (t) => {
+test('invalid url type', t => {
   t.throws(() => request(init({ method: 'GET', url: 5 }), 0, makeAssay()), {
     name: 'InvalidRequestUrl',
     message: 'Request URL must be a string',
   })
 })
 
-test('invalid url format', (t) => {
+test('invalid url format', t => {
   t.throws(
     () => request(init({ method: 'GET', url: 'example.com' }), 0, makeAssay()),
     {
@@ -52,7 +52,7 @@ test('invalid url format', (t) => {
   )
 })
 
-test('invalid queryString', (t) => {
+test('invalid queryString', t => {
   t.throws(
     () =>
       request(
@@ -68,7 +68,7 @@ test('invalid queryString', (t) => {
   )
 })
 
-test('invalid headers', (t) => {
+test('invalid headers', t => {
   t.throws(
     () =>
       request(
@@ -84,7 +84,7 @@ test('invalid headers', (t) => {
   )
 })
 
-test('invalid cookies', (t) => {
+test('invalid cookies', t => {
   t.throws(
     () =>
       request(
@@ -100,7 +100,7 @@ test('invalid cookies', (t) => {
   )
 })
 
-test('invalid postData', (t) => {
+test('invalid postData', t => {
   t.throws(
     () =>
       request(
@@ -116,7 +116,7 @@ test('invalid postData', (t) => {
   )
 })
 
-test('invalid comment', (t) => {
+test('invalid comment', t => {
   t.throws(
     () =>
       request(
@@ -132,8 +132,8 @@ test('invalid comment', (t) => {
   )
 })
 
-test('GET with body', (t) => {
-  t.throws(
+test('GET with body', t => {
+  t.notThrows(
     () => {
       request(
         {
@@ -149,7 +149,7 @@ test('GET with body', (t) => {
   )
 })
 
-test('inconsistent Content-Type', (t) => {
+test('inconsistent Content-Type', t => {
   t.notThrows(() =>
     request(
       init({
@@ -164,7 +164,7 @@ test('inconsistent Content-Type', (t) => {
   )
 })
 
-test('consistent Content-Type', (t) => {
+test('consistent Content-Type', t => {
   t.notThrows(() =>
     request(
       {
@@ -179,32 +179,32 @@ test('consistent Content-Type', (t) => {
   )
 })
 
-test('valid http url', (t) => {
+test('valid http url', t => {
   t.notThrows(() => {
     request(init({ method: 'GET', url: 'http://example.com' }), 0, makeAssay())
   })
 })
 
-test('valid https url', (t) => {
+test('valid https url', t => {
   t.notThrows(() => {
     request(init({ method: 'GET', url: 'https://example.com' }), 0, makeAssay())
   })
 })
 
-test('valid ftp url', (t) => {
+test('valid ftp url', t => {
   t.notThrows(() => {
     request(init({ method: 'GET', url: 'ftp://example.com' }), 0, makeAssay())
   })
 })
 
-test('valid variable url', (t) => {
+test('valid variable url', t => {
   /* eslint-disable-next-line no-template-curly-in-string */
   t.notThrows(() => {
     request(init({ method: 'GET', url: '${base}/index.html' }), 0, makeAssay())
   })
 })
 
-test('valid full', (t) => {
+test('valid full', t => {
   t.notThrows(() => {
     request(
       init({


### PR DESCRIPTION
This PR contains a number of smaller fixes, making the converter more tolerant to deviations from the HAR specification.

* [fix] param not discarded when name is empty
* [fix] query items with a null name throws validation error
* [fix] validation error thrown when GET request has postData

It also adds a small feature where the converter will try to infer the mime type when it is missing, by looking at the rest of the postData content.

Also updated a bunch of test names to make them more descriptive and removed some unused code.