### PR TITLE
fix: type definition of `pageref` in Entry

### DIFF
--- a/typings/main.d.ts
+++ b/typings/main.d.ts
@@ -448,7 +448,7 @@ declare module 'har-to-k6' {
      *
      * Must be unique.
      */
-    pageRef?: string
+    pageref?: string
 
     /**
      * Date and time stamp of the request start (ISO 8601 - YYYY-MM-DDThh:mm:ss.sTZD).


### PR DESCRIPTION
This pull request renames the field `pageRef` under the `Entry` interface to `pageref` to keep it consistent with other occurrences in the codebase as well as the W3C specification (although it is still a draft).