### PR TITLE
Feature/add websocket functionallity

### DIFF
--- a/bin/har-to-k6.js
+++ b/bin/har-to-k6.js
@@ -13,7 +13,6 @@ class CommandLineError extends VError {}
 const BOM_REGEX = /^\uFEFF/
 
 pkginfo(module, 'version')
-
 const version = module.exports.version
 delete module.exports.version
 

--- a/bin/har-to-k6.js
+++ b/bin/har-to-k6.js
@@ -13,6 +13,7 @@ class CommandLineError extends VError {}
 const BOM_REGEX = /^\uFEFF/
 
 pkginfo(module, 'version')
+
 const version = module.exports.version
 delete module.exports.version
 

--- a/src/aid.js
+++ b/src/aid.js
@@ -35,8 +35,8 @@ function isNil(value) {
 }
 
 function parseContentType(str = '') {
-  const [mimeType, ...rest] = str.split(';').map((s) => s.trim())
-  const params = objectFromEntries(rest.map((s) => s.split('=')))
+  const [mimeType, ...rest] = str.split(';').map(s => s.trim())
+  const params = objectFromEntries(rest.map(s => s.split('=')))
 
   return {
     ...params,
@@ -53,8 +53,7 @@ function isBlacklistedHeader(headerName = '') {
   const [name] = headerName.split(';')
 
   return HEADERS_BLACKLIST.some(
-    (blacklistedHeader) =>
-      name.toLowerCase() === blacklistedHeader.toLowerCase()
+    blacklistedHeader => name.toLowerCase() === blacklistedHeader.toLowerCase()
   )
 }
 
@@ -79,6 +78,10 @@ function isMultipartFormData(entry) {
   return entry.request.postData.mimeType.includes('multipart/form-data')
 }
 
+function isWebsocket(url) {
+  return ['ws:', 'wss'].includes(url.slice(0, 3))
+}
+
 module.exports = {
   seralizeURLSearchParams,
   empty,
@@ -91,4 +94,5 @@ module.exports = {
   parseContentType,
   getContentTypeValue,
   isMultipartFormData,
+  isWebsocket,
 }

--- a/src/convert.js
+++ b/src/convert.js
@@ -29,7 +29,7 @@ async function convert(_archives, options = DEFAULT_OPTIONS) {
       )
     }
 
-    return parse(source)
+    return parse(source, options)
   })
 
   const imports = combineImports(result)

--- a/src/make.js
+++ b/src/make.js
@@ -29,6 +29,8 @@ function entrySpec() {
     checks: new Map(),
     variables: new Map(),
     state: entryState(),
+    webSocketMessages: [],
+    addSleep: false,
   }
 }
 
@@ -44,6 +46,7 @@ function imports() {
     group: false,
     check: false,
     http: false,
+    websocket: false,
 
     // jslib.k6.io
     URLSearchParams: false,
@@ -71,6 +74,18 @@ function postState() {
 function queryState() {
   return {
     variable: null,
+  }
+}
+
+function websocketFactor() {
+  return {
+    method: null,
+    address: null,
+    headers: null,
+    cookies: null,
+    options: null,
+    messages: null,
+    timeAlive: 0,
   }
 }
 
@@ -119,6 +134,7 @@ function result() {
     declares: new Set(),
     exportAs: '',
     defaultExport: true,
+    addSleep: false,
   }
 }
 
@@ -132,6 +148,7 @@ module.exports = {
   paramsState,
   postState,
   queryState,
+  websocketFactor,
   requestFactor,
   requestSpec,
   requestState,

--- a/src/parse/entry.js
+++ b/src/parse/entry.js
@@ -23,6 +23,11 @@ function entry(node, result) {
   if (node.variables) {
     variables(node.variables, spec.variables)
   }
+  if (node._webSocketMessages) {
+    // capture all the websocket messages for later use connecting to the websocket
+    spec.timeConnected = node.time
+    spec.webSocketMessages = node._webSocketMessages
+  }
   state(spec)
   result.entries.push(spec)
 }

--- a/src/parse/flow.js
+++ b/src/parse/flow.js
@@ -1,9 +1,12 @@
 const { FlowItemType } = require('../enum')
 
 // Resolve control flow
-function flow(result) {
+function flow(result, options) {
   const processed = new Set()
   for (const entry of result.entries) {
+    if (options) {
+      entry.addSleep = options.addSleep
+    }
     item(entry, result, processed, result.flow)
   }
 }
@@ -27,7 +30,7 @@ function external(entry, items) {
 function grouped(page, result, processed, items) {
   if (!processed.has(page)) {
     processed.add(page)
-    const entries = result.entries.filter((entry) => entry.page === page)
+    const entries = result.entries.filter(entry => entry.page === page)
     const item = {
       type: FlowItemType.Group,
       id: page,

--- a/src/parse/imports.js
+++ b/src/parse/imports.js
@@ -7,7 +7,7 @@ const {
 } = require('../enum')
 
 const { UnrecognizedError } = require('../error')
-const { isMultipartFormData } = require('../aid')
+const { isMultipartFormData, isWebsocket } = require('../aid')
 
 function imports(archive, result) {
   if (archive.log.entries) {
@@ -15,11 +15,11 @@ function imports(archive, result) {
     result.imports.sleep = true
     const entries = archive.log.entries
 
-    if (entries.find((entry) => entry.pageref)) {
+    if (entries.find(entry => entry.pageref)) {
       result.imports.group = true
     }
 
-    if (entries.find((entry) => entry.checks && entry.checks.length)) {
+    if (entries.find(entry => entry.checks && entry.checks.length)) {
       result.imports.check = true
     }
 
@@ -42,7 +42,27 @@ function imports(archive, result) {
     if (result.flow.find(MimeBuilderFlowItem)) {
       result.imports.MimeBuilder = true
     }
+    if (webSocketItem(entries)) {
+      result.imports.websocket = true
+    }
+    if (requestItem(entries)) {
+      result.imports.http = true
+    }
   }
+}
+
+function webSocketItem(entries) {
+  // This function checkes to see if a request is a websocket
+  //  request to make sure imports has websocket true
+  const check = ({ request }) => isWebsocket(request.url)
+  return entries.find(check)
+}
+
+function requestItem(entries) {
+  // This function checkes to see if a request is NOT a websocket
+  //  request to make sure imports has http true
+  const check = ({ request }) => !isWebsocket(request.url)
+  return entries.find(check)
 }
 
 function jsonPathEntry(entry) {

--- a/src/parse/index.js
+++ b/src/parse/index.js
@@ -4,10 +4,10 @@ const imports = require('./imports')
 const root = require('./root')
 const { result: makeResult } = require('../make')
 
-function parse(archive) {
+function parse(archive, options) {
   const result = makeResult()
   root(archive, result)
-  flow(result)
+  flow(result, options)
   imports(archive, result)
   declares(archive, result)
 

--- a/src/render/entry/logic.js
+++ b/src/render/entry/logic.js
@@ -1,11 +1,13 @@
 const checks = require('../checks')
 const request = require('../request')
+const websocket = require('../websocket')
 const variables = require('../variables')
 const withSleep = require('../withSleep')
+const { isWebsocket } = require('../../aid')
 
 function logic(spec) {
   let flow = [
-    request(spec.request),
+    communicationProtocol(spec),
     checks(spec.checks),
     variables(spec.variables),
   ]
@@ -14,7 +16,14 @@ function logic(spec) {
     flow = withSleep(flow, spec.sleep)
   }
 
-  return flow.filter((item) => item).join(`\n`)
+  return flow.filter(item => item).join(`\n`)
+}
+
+function communicationProtocol(spec) {
+  if (spec.request.address && isWebsocket(spec.request.address)) {
+    return websocket(spec)
+  }
+  return request(spec.request)
 }
 
 module.exports = logic

--- a/src/render/headers.js
+++ b/src/render/headers.js
@@ -1,10 +1,28 @@
 const header = require('./header')
 const object = require('./object')
 
+function filterHeaders(allEntries) {
+  const preGeneratedHeaders = [
+    'sec-websocket-key',
+    'upgrade',
+    'sec-websocket-version',
+    'sec-websocket-extensions',
+    'connection',
+  ]
+  const entries = allEntries.filter(function (current) {
+    if (current === undefined) {
+      return current
+    }
+    return !preGeneratedHeaders.includes(current.name.toLowerCase())
+  })
+  return entries
+}
+
 function headers(spec) {
   if (spec.size) {
     const entries = [...spec].map(([name, items]) => header(name, items))
-    return object(entries)
+    const filteredEntries = filterHeaders(entries)
+    return object(filteredEntries)
   } else {
     return null
   }

--- a/src/render/imports.js
+++ b/src/render/imports.js
@@ -3,6 +3,7 @@ function imports(spec) {
     const lines = []
     k6(spec, lines)
     http(spec, lines)
+    websocket(spec, lines)
     k6JsLibs(spec, lines)
     return lines.join(`\n`)
   } else {
@@ -11,7 +12,7 @@ function imports(spec) {
 }
 
 function any(spec) {
-  return Object.values(spec).find((value) => value)
+  return Object.values(spec).find(value => value)
 }
 
 function k6(spec, lines) {
@@ -27,11 +28,20 @@ function k6(spec, lines) {
     if (spec.group) {
       items.push('group')
     }
+    if (spec.websocket) {
+      items.push('fail')
+    }
   }
 
   const content = items.join(`, `)
   if (items.length > 0) {
     lines.push(`import { ${content} } from "k6";`)
+  }
+}
+
+function websocket(spec, lines) {
+  if (spec.websocket) {
+    lines.push(`import ws from 'k6/ws';`)
   }
 }
 

--- a/src/render/websocket.js
+++ b/src/render/websocket.js
@@ -1,0 +1,190 @@
+const headers = require('./headers')
+const cookies = require('./cookies')
+const address = require('./address')
+const object = require('./object')
+const { websocketFactor: makeWebsocketFactor } = require('../make')
+
+function websocket(spec) {
+  let factor = getFactor(spec.request, spec)
+  return render(factor)
+}
+
+function getFactor(request, spec) {
+  const factor = makeWebsocketFactor()
+  if (spec.addSleep) {
+    factor.timeAlive = timeAlive(spec.timeConnected, spec.webSocketMessages)
+    factor.addSleep = spec.addSleep
+    factor.messages = changeMessageTimes(spec.webSocketMessages)
+  } else {
+    factor.messages = spec.webSocketMessages
+  }
+  factor.call = 'connect'
+  address(request, factor)
+  factor.headers = headers(request.headers)
+  factor.cookies = cookies(request.cookies)
+  factor.options = options(factor)
+  factor.args = args(factor)
+
+  return factor
+}
+
+function changeMessageTimes(messages) {
+  /// calculates when to sleep between messages
+  if (messages.length != 0) {
+    let firstTimeStartsAtZero = 0
+    let firstIndexSetToZero = 0
+    let messagesWithNewTimes = JSON.parse(JSON.stringify(messages))
+    messagesWithNewTimes[firstIndexSetToZero].time = firstTimeStartsAtZero
+    for (let i = 1; i < messages.length; i++) {
+      messagesWithNewTimes[i].time =
+        (messages[i].time - messages[i - 1].time) * 1000 // 1000 millisecond multiplier
+    }
+    var sum = messagesWithNewTimes.reduce((accum, curr) => {
+      return accum + curr.time
+    }, 0)
+    for (var i = messagesWithNewTimes.length - 1; i >= 0; i--) {
+      sum = sum - messagesWithNewTimes[i].time
+      messagesWithNewTimes[i].time = sum
+    }
+    return messagesWithNewTimes
+  }
+}
+
+function timeAlive(timeConnected, messages) {
+  /// calculates length of time when websocket is open minus the total time the messages took to run before closing the socket
+  let time = timeConnected
+  if (messages.length > 1) {
+    let firstMessageTime = messages[0].time
+    let finalMessageTime = messages[messages.length - 1].time
+    let totalTimeMessagesTook = finalMessageTime - firstMessageTime
+    time = timeConnected - totalTimeMessagesTook
+  }
+  return time
+}
+
+function ws_send_messages(factor) {
+  // generates websocket functionality code
+  let socket_function = [
+    ' function (socket) {',
+    'let timings = { } ',
+    'const messages = [',
+  ]
+  let send_messages = [
+    `socket.on('message', function (mes) {`,
+    `if (mes.startsWith('44')) {`,
+    'socket.close()',
+    'fail(`Websocket Message Failure: ${mes}`)',
+    '}',
+  ]
+  if (factor.addSleep) {
+    send_messages.push(
+      ...[
+        'const parsedMessage = JSON.parse(mes)',
+        'if (parsedMessage.type === "start" || parsedMessage.type === "connection_ack") {',
+        'messages.forEach(function (currentMessage) {',
+        'socket.setTimeout(function () {',
+        'const date = new Date()',
+        'const startTime = date.getTime()',
+        'const currentId = JSON.parse(currentMessage.message).id',
+        'timings[currentId] = startTime',
+        'socket.send(currentMessage.message)',
+        '}, currentMessage.time)',
+        '})',
+        '} else {',
+        'const date = new Date()',
+        'const currentId = parsedMessage.id',
+        'if (timings[currentId] !== undefined) {',
+        'const endTime = date.getTime()',
+        'const startTime = timings[currentId]',
+        'const totalResponseTime = endTime - startTime',
+        // 'wsResponseTrend.add(totalResponseTime)',
+        '}',
+        '}',
+      ]
+    )
+  }
+
+  send_messages.push('})')
+  let messages = factor.messages
+  let timeAlive = 2
+  send_messages.push("socket.on('open', function () {")
+  if (messages) {
+    for (const message of messages) {
+      if (message.type === 'send') {
+        let parsed_data = JSON.parse(message.data)
+        if (
+          parsed_data.type === 'connection_init' ||
+          parsed_data.type === 'start' ||
+          !factor.addSleep
+        ) {
+          send_messages.push(`socket.send(${JSON.stringify(message.data)})`)
+        } else {
+          socket_function.push(
+            ...[
+              '{',
+              `message: ${JSON.stringify(message.data)},`,
+              `time: ${message.time},`,
+              '},',
+            ]
+          )
+        }
+      }
+    }
+  }
+  if (factor.addSleep && factor.timeAlive > 0) {
+    timeAlive = factor.timeAlive
+  }
+  send_messages.push(
+    ...[
+      'socket.setTimeout(function () {',
+      'socket.close()',
+      `}, ${timeAlive})`,
+      '})',
+      "socket.on('error', function (e) {",
+      'fail(`WebSocket failed: ${e.error()}`);',
+      '})',
+      '}',
+    ]
+  )
+  socket_function.push(']')
+  socket_function.push(...send_messages)
+  return socket_function.join('\n')
+}
+
+function args(factor) {
+  // creates list of generated code for use in main code generation
+  const items = []
+  items.push(factor.address)
+  if (factor.options) {
+    items.push(factor.options)
+  }
+  items.push(ws_send_messages(factor))
+
+  return items
+}
+
+function options(factor) {
+  if (factor.headers || factor.cookies) {
+    const entries = []
+    if (factor.headers) {
+      entries.push({ name: 'headers', value: factor.headers })
+    }
+    if (factor.cookies) {
+      entries.push({ name: 'cookies', value: factor.cookies })
+    }
+    return object(entries)
+  } else {
+    return null
+  }
+}
+
+function main(factor) {
+  const list = factor.args.join(`, `)
+  return `ws.${factor.call}(${list});`
+}
+
+function render(factor) {
+  return [main(factor)].filter(item => item).join(`\n`)
+}
+
+module.exports = websocket

--- a/src/render/websocket.js
+++ b/src/render/websocket.js
@@ -69,13 +69,7 @@ function ws_send_messages(factor) {
     'let timings = { } ',
     'const messages = [',
   ]
-  let send_messages = [
-    `socket.on('message', function (mes) {`,
-    `if (mes.startsWith('44')) {`,
-    'socket.close()',
-    'fail(`Websocket Message Failure: ${mes}`)',
-    '}',
-  ]
+  let send_messages = [`socket.on('message', function (mes) {`]
   if (factor.addSleep) {
     send_messages.push(
       ...[

--- a/test/unit/parse/entry.test.js
+++ b/test/unit/parse/entry.test.js
@@ -23,6 +23,8 @@ test.serial('basic', t => {
       variables: new Map(),
       sleep: null,
       state: { expanded: true },
+      webSocketMessages: [],
+      addSleep: false,
     },
   ])
   t.true(request.calledOnce)
@@ -55,4 +57,12 @@ test.serial('variables', t => {
 test.serial('sleep', t => {
   entry({ sleep: 1200 }, makeResult())
   t.true(sleep.calledOnce)
+})
+
+test.serial('webSocketMessages', t => {
+  let testMessage = 'Hello I am a test message'
+  let node = { time: 420, _webSocketMessages: [testMessage] }
+  let result = makeResult()
+  entry(node, result)
+  t.is(result.entries[0].webSocketMessages[0], testMessage)
 })

--- a/test/unit/render/address/fixed.js
+++ b/test/unit/render/address/fixed.js
@@ -3,6 +3,7 @@ const isolate = require('helper/isolate')
 const {
   requestFactor: makeRequestFactor,
   requestSpec: makeRequestSpec,
+  websocketFactor: makeWebsocketFactor,
 } = require('make')
 const [fixed, { string }] = isolate(test, 'render/address/fixed', {
   string: 'render/string',
@@ -16,4 +17,12 @@ test('basic', t => {
   fixed(spec, factor)
   t.is(factor.address, '"http://example.com"')
   t.deepEqual(factor.pre, [])
+
+  string.returns('"wss://example.com"')
+  const ws_factor = makeWebsocketFactor()
+  const ws_spec = makeRequestSpec()
+  spec.address = 'wss://example.com'
+  fixed(ws_spec, ws_factor)
+  t.is(ws_factor.address, '"wss://example.com"')
+  t.deepEqual(ws_factor.pre, undefined)
 })

--- a/test/unit/render/imports.test.js
+++ b/test/unit/render/imports.test.js
@@ -22,6 +22,13 @@ test('http', t => {
   t.is(result, `import http from "k6/http";`)
 })
 
+test('webSocket', t => {
+  const spec = makeImports()
+  spec.websocket = true
+  const result = imports(spec)
+  t.is(result, `import ws from 'k6/ws';`)
+})
+
 test('sleep', t => {
   const spec = makeImports()
   spec.sleep = true


### PR DESCRIPTION
# Description
 This pull request is a feature that allows the `har-to-k6` converter to handle web-socket functionality. It uses the k6 library `import ws from 'k6/ws'`. These requests were formerly ignored in the original itteration of `har-to-k6`.
## Type of change
- This version handles the websocket `send(...)` messages and adds a `setTimeout` in place of `sleep` for websockets, this is because k6 websocket callbacks are not made to work with the `sleep(...)` function.
- Websocket send messages are the only messages that are handled here
- Once the file is converted, if you have specific timings or order that needs to be handled you must add that yourself.
- This is very generic to support many different kinds of websocket testing