### PR TITLE
fix: Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,17 @@ FROM node:20-alpine
 
 WORKDIR /converter
 
-COPY . .
-
+# Install dependencies
+COPY package.json package-lock.json ./
+COPY webpack.config.js .editorconfig .eslintignore .prettierignore ./
+COPY src src
+COPY typings typings
+COPY LICENSE ./
 RUN npm install
+
+# Bundle app source
 RUN npm run bundle
 
+# Bundle bin source
+COPY bin bin
 ENTRYPOINT ["node", "bin/har-to-k6.js", "--stdout"]


### PR DESCRIPTION
Prevent Github token from being exposed during build.

This PR is in response to an incident raised internally: https://raintank-corp.slack.com/archives/C08DR6C4KU5

## How to test
- run: `docker build . -t har-to-k6`

